### PR TITLE
fixed an error with improper matrix dimensions

### DIFF
--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -192,7 +192,9 @@ class PyramidDiTForVideoGeneration:
 
     def sample_block_noise(self, bs, ch, temp, height, width):
         gamma = self.scheduler.config.gamma
-        dist = torch.distributions.multivariate_normal.MultivariateNormal(torch.zeros(4), torch.eye(4) * (1 + gamma) - torch.ones(4, 4) * gamma)
+        epsilon = 1e-5  # Small value to ensure positive definiteness
+        covariance_matrix = torch.eye(4) * (1 + gamma) - torch.ones(4, 4) * gamma + torch.eye(4) * epsilon
+        dist = torch.distributions.multivariate_normal.MultivariateNormal(torch.zeros(4), covariance_matrix)
         block_number = bs * ch * temp * (height // 2) * (width // 2)
         noise = torch.stack([dist.sample() for _ in range(block_number)]) # [block number, 4]
         noise = rearrange(noise, '(b c t h w) (p q) -> b c t (h p) (w q)',b=bs,c=ch,t=temp,h=height//2,w=width//2,p=2,q=2)


### PR DESCRIPTION
#3 I reverted the covariance matrix calculation to it's previous calculation before [this commit](https://github.com/kijai/ComfyUI-PyramidFlowWrapper/commit/8c18421294f433d75b40210e46088c4877329f2e) to fix an issue with improper matrix dimensions. This fixed the issue for me, although I don't know enough about this to be sure this is the correct solution.